### PR TITLE
Fix YAML parse error in unity-graphics globs frontmatter

### DIFF
--- a/skills/unity-graphics/SKILL.md
+++ b/skills/unity-graphics/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Unity 6 graphics and rendering guide. Use when working with render pipelines (URP, HDRP, Built-in), shaders, Shader Graph, materials, textures, cameras, post-processing, or rendering optimization. Covers Render Graph, batching, draw call optimization, and GPU instancing. Based on Unity 6.3 LTS documentation.
 globs:
   - "**/*.shader"
-  - "**/*.hlsl"  - "**/*.shadergraph"
+  - "**/*.hlsl"
+  - "**/*.shadergraph"
   - "**/*.shadersubgraph"
   - "**/*.mat"
 ---


### PR DESCRIPTION
## Summary

The `unity-graphics` skill silently fails to register in Claude Code at v1.4.0 because its YAML frontmatter has two `globs` list items on the same line:

```yaml
globs:
  - "**/*.shader"
  - "**/*.hlsl"  - "**/*.shadergraph"   # ← parser breaks here
  - "**/*.shadersubgraph"
  - "**/*.mat"
```

PyYAML reports this as `ScannerError: sequence entries are not allowed here` at column 18 of line 7. Claude Code's plugin loader treats the file as having no parseable frontmatter and skips registering the skill — so installs of the `unity` plugin currently expose 34 of the advertised 35 skills (`unity-graphics` is missing from the loaded list).

## Fix

Split the two list items onto separate lines so the YAML parses correctly. No content changes; same five glob patterns.

```yaml
globs:
  - "**/*.shader"
  - "**/*.hlsl"
  - "**/*.shadergraph"
  - "**/*.shadersubgraph"
  - "**/*.mat"
```

## Verification

```bash
$ python3 -c "import yaml; print(yaml.safe_load(open('SKILL.md').read().split('---')[1]))"
{'name': 'unity-graphics', 'description': '...', 'globs': ['**/*.shader', '**/*.hlsl', '**/*.shadergraph', '**/*.shadersubgraph', '**/*.mat']}
```

After applying the patch and restarting Claude Code, `unity:unity-graphics` appears in the skill list alongside the other 34.

## Test plan

- [x] YAML parses cleanly with PyYAML
- [x] Skill loads in Claude Code (`unity:unity-graphics` visible in available skills after restart)
- [x] No content changes to the skill body

🤖 Generated with [Claude Code](https://claude.com/claude-code)